### PR TITLE
feat: add `tsTransformIsort`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "vitest": "^0.28.5"
   },
   "peerDependencies": {
-    "jscodeshift": "*"
+    "jscodeshift": "*",
+    "typescript": "*"
   },
   "volta": {
     "node": "18.14.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/jscodeshift": "^0.11.6",
     "@types/lodash": "^4.14.191",
     "@types/node": "^18.14.1",
+    "@types/prettier": "^2.7.2",
     "ast-types": "^0.14.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.3",
@@ -47,6 +48,7 @@
   },
   "peerDependencies": {
     "jscodeshift": "*",
+    "prettier": "*",
     "typescript": "*"
   },
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@types/jscodeshift': ^0.11.6
   '@types/lodash': ^4.14.191
   '@types/node': ^18.14.1
+  '@types/prettier': ^2.7.2
   ast-types: ^0.14.2
   jscodeshift: ^0.14.0
   lodash: ^4.17.21
@@ -25,6 +26,7 @@ devDependencies:
   '@types/jscodeshift': 0.11.6
   '@types/lodash': 4.14.191
   '@types/node': 18.14.1
+  '@types/prettier': 2.7.2
   ast-types: 0.14.2
   npm-run-all: 4.1.5
   prettier: 2.8.4
@@ -942,6 +944,10 @@ packages:
 
   /@types/node/18.14.1:
     resolution: {integrity: sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==}
+    dev: true
+
+  /@types/prettier/2.7.2:
+    resolution: {integrity: sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==}
     dev: true
 
   /@vitest/expect/0.28.5:

--- a/src/transform-isort.ts
+++ b/src/transform-isort.ts
@@ -17,6 +17,8 @@ const options: IsortOptions = {
   isortCaseInsensitive: true,
 };
 
+export { options as DEFAULT_OPTIONS };
+
 export const transformIsort: Transform = (file, api, _options) => {
   const j = api.jscodeshift;
   const $j = j(file.source);
@@ -97,7 +99,7 @@ export const transformIsort: Transform = (file, api, _options) => {
 // utils
 //
 
-function groupNeighborBy<T, K>(ls: T[], f: (x: T) => K): [K, T[]][] {
+export function groupNeighborBy<T, K>(ls: T[], f: (x: T) => K): [K, T[]][] {
   if (ls.length === 0) {
     return [];
   }

--- a/src/typescript/cli.ts
+++ b/src/typescript/cli.ts
@@ -1,0 +1,55 @@
+import { partition } from "lodash";
+import fs from "node:fs";
+import process from "node:process";
+import { tsTransformIsort } from "./transformer";
+
+//
+// simple standalone cli
+//
+// usage:
+//   node ./dist/typescript/cli.js $(git grep -l . '*.ts')
+//
+
+async function main() {
+  const args = process.argv.slice(2);
+  const [fixArgs, filePaths] = partition(args, (v) => v === "--fix");
+  const fixMode = fixArgs.length > 0;
+
+  const results = {
+    ok: 0,
+    nochange: 0,
+    error: 0,
+  };
+
+  for (const filePath of filePaths) {
+    try {
+      const input = await fs.promises.readFile(filePath, "utf-8");
+      const output = tsTransformIsort(input);
+      if (output !== input) {
+        if (fixMode) {
+          await fs.promises.writeFile(filePath, output);
+        }
+        console.log("[OKK]", filePath);
+        results.ok++;
+      } else {
+        console.log("[NOC]", filePath);
+        results.nochange++;
+      }
+    } catch (e) {
+      console.log("[ERR]", filePath);
+      results.error++;
+    }
+  }
+
+  if (fixMode) {
+    if (results.error) {
+      process.exit(1);
+    }
+  } else {
+    if (results.ok || results.error) {
+      process.exit(1);
+    }
+  }
+}
+
+main();

--- a/src/typescript/prettier-plugin.ts
+++ b/src/typescript/prettier-plugin.ts
@@ -1,0 +1,17 @@
+import type prettier from "prettier";
+import parserTypescript from "prettier/parser-typescript";
+import { tsTransformIsort } from "./transformer";
+
+// usage:
+//   npx prettier --write . --plugin=./dist/typescript/prettier-plugin.js
+
+const plugin: prettier.Plugin = {
+  parsers: {
+    typescript: {
+      ...parserTypescript.parsers.typescript,
+      preprocess: tsTransformIsort,
+    },
+  },
+};
+
+module.exports = plugin;

--- a/src/typescript/transformer.test.ts
+++ b/src/typescript/transformer.test.ts
@@ -9,7 +9,7 @@ import "c";
 import { z, w } from "a";
 `;
     expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
-      "import { z, w } from \\"a\\";
+      "import { w, z } from \\"a\\";
       import { x, y } from \\"b\\";
       import \\"c\\";
       "
@@ -19,19 +19,16 @@ import { z, w } from "a";
         [
           {
             "end": 25,
-            "fullStart": 0,
             "source": "b",
             "specifiers": [
               {
                 "end": 10,
-                "fullStart": 8,
                 "imported": undefined,
                 "name": "x",
                 "start": 9,
               },
               {
                 "end": 13,
-                "fullStart": 11,
                 "imported": undefined,
                 "name": "y",
                 "start": 12,
@@ -41,26 +38,22 @@ import { z, w } from "a";
           },
           {
             "end": 37,
-            "fullStart": 25,
             "source": "c",
             "specifiers": undefined,
             "start": 26,
           },
           {
             "end": 63,
-            "fullStart": 37,
             "source": "a",
             "specifiers": [
               {
                 "end": 48,
-                "fullStart": 46,
                 "imported": undefined,
                 "name": "z",
                 "start": 47,
               },
               {
                 "end": 51,
-                "fullStart": 49,
                 "imported": undefined,
                 "name": "w",
                 "start": 50,
@@ -83,7 +76,7 @@ import { z, w } from "a";
 `;
     expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
       "// hey
-      import { z, w } from \\"a\\";
+      import { w, z } from \\"a\\";
       import { x, y } from \\"b\\"; // xxx
       // foo
       import \\"c\\";
@@ -94,19 +87,16 @@ import { z, w } from "a";
         [
           {
             "end": 32,
-            "fullStart": 0,
             "source": "b",
             "specifiers": [
               {
                 "end": 17,
-                "fullStart": 15,
                 "imported": undefined,
                 "name": "x",
                 "start": 16,
               },
               {
                 "end": 20,
-                "fullStart": 18,
                 "imported": undefined,
                 "name": "y",
                 "start": 19,
@@ -116,26 +106,22 @@ import { z, w } from "a";
           },
           {
             "end": 44,
-            "fullStart": 32,
             "source": "c",
             "specifiers": undefined,
             "start": 33,
           },
           {
             "end": 84,
-            "fullStart": 44,
             "source": "a",
             "specifiers": [
               {
                 "end": 69,
-                "fullStart": 67,
                 "imported": undefined,
                 "name": "z",
                 "start": 68,
               },
               {
                 "end": 72,
-                "fullStart": 70,
                 "imported": undefined,
                 "name": "w",
                 "start": 71,
@@ -159,7 +145,7 @@ import { z, w } from "a";
       "import { x, y } from \\"b\\";
       // isort-ignore
       import \\"c\\";
-      import { z, w } from \\"a\\";
+      import { w, z } from \\"a\\";
       "
     `);
     expect(tsAnalyze(input)).toMatchInlineSnapshot(`
@@ -167,19 +153,16 @@ import { z, w } from "a";
         [
           {
             "end": 25,
-            "fullStart": 0,
             "source": "b",
             "specifiers": [
               {
                 "end": 10,
-                "fullStart": 8,
                 "imported": undefined,
                 "name": "x",
                 "start": 9,
               },
               {
                 "end": 13,
-                "fullStart": 11,
                 "imported": undefined,
                 "name": "y",
                 "start": 12,
@@ -191,19 +174,16 @@ import { z, w } from "a";
         [
           {
             "end": 79,
-            "fullStart": 53,
             "source": "a",
             "specifiers": [
               {
                 "end": 64,
-                "fullStart": 62,
                 "imported": undefined,
                 "name": "z",
                 "start": 63,
               },
               {
                 "end": 67,
-                "fullStart": 65,
                 "imported": undefined,
                 "name": "w",
                 "start": 66,
@@ -226,7 +206,7 @@ import { z, w } from "a";
     expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
       "import { x, y } from \\"b\\";
       \\"hello\\";
-      import { z, w } from \\"a\\";
+      import { w, z } from \\"a\\";
       import \\"c\\";
       "
     `);
@@ -235,19 +215,16 @@ import { z, w } from "a";
         [
           {
             "end": 25,
-            "fullStart": 0,
             "source": "b",
             "specifiers": [
               {
                 "end": 10,
-                "fullStart": 8,
                 "imported": undefined,
                 "name": "x",
                 "start": 9,
               },
               {
                 "end": 13,
-                "fullStart": 11,
                 "imported": undefined,
                 "name": "y",
                 "start": 12,
@@ -259,26 +236,22 @@ import { z, w } from "a";
         [
           {
             "end": 46,
-            "fullStart": 34,
             "source": "c",
             "specifiers": undefined,
             "start": 35,
           },
           {
             "end": 72,
-            "fullStart": 46,
             "source": "a",
             "specifiers": [
               {
                 "end": 57,
-                "fullStart": 55,
                 "imported": undefined,
                 "name": "z",
                 "start": 56,
               },
               {
                 "end": 60,
-                "fullStart": 58,
                 "imported": undefined,
                 "name": "w",
                 "start": 59,
@@ -310,14 +283,12 @@ import "a";
         [
           {
             "end": 11,
-            "fullStart": 0,
             "source": "b",
             "specifiers": undefined,
             "start": 0,
           },
           {
             "end": 23,
-            "fullStart": 11,
             "source": "a",
             "specifiers": undefined,
             "start": 12,

--- a/src/typescript/transformer.test.ts
+++ b/src/typescript/transformer.test.ts
@@ -23,13 +23,11 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 10,
-                "imported": undefined,
                 "name": "x",
                 "start": 9,
               },
               {
                 "end": 13,
-                "imported": undefined,
                 "name": "y",
                 "start": 12,
               },
@@ -48,18 +46,49 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 48,
-                "imported": undefined,
                 "name": "z",
                 "start": 47,
               },
               {
                 "end": 51,
-                "imported": undefined,
                 "name": "w",
                 "start": 50,
               },
             ],
             "start": 38,
+          },
+        ],
+      ]
+    `);
+  });
+
+  it("rename", () => {
+    const input = `\
+import { y as a, x as b } from "b";
+`;
+    expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
+      "import { x as b, y as a } from \\"b\\";
+      "
+    `);
+    expect(tsAnalyze(input)).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "end": 35,
+            "source": "b",
+            "specifiers": [
+              {
+                "end": 15,
+                "name": "y",
+                "start": 9,
+              },
+              {
+                "end": 23,
+                "name": "x",
+                "start": 17,
+              },
+            ],
+            "start": 0,
           },
         ],
       ]
@@ -91,13 +120,11 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 17,
-                "imported": undefined,
                 "name": "x",
                 "start": 16,
               },
               {
                 "end": 20,
-                "imported": undefined,
                 "name": "y",
                 "start": 19,
               },
@@ -116,13 +143,11 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 69,
-                "imported": undefined,
                 "name": "z",
                 "start": 68,
               },
               {
                 "end": 72,
-                "imported": undefined,
                 "name": "w",
                 "start": 71,
               },
@@ -157,13 +182,11 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 10,
-                "imported": undefined,
                 "name": "x",
                 "start": 9,
               },
               {
                 "end": 13,
-                "imported": undefined,
                 "name": "y",
                 "start": 12,
               },
@@ -178,13 +201,11 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 64,
-                "imported": undefined,
                 "name": "z",
                 "start": 63,
               },
               {
                 "end": 67,
-                "imported": undefined,
                 "name": "w",
                 "start": 66,
               },
@@ -219,13 +240,11 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 10,
-                "imported": undefined,
                 "name": "x",
                 "start": 9,
               },
               {
                 "end": 13,
-                "imported": undefined,
                 "name": "y",
                 "start": 12,
               },
@@ -246,13 +265,11 @@ import { z, w } from "a";
             "specifiers": [
               {
                 "end": 57,
-                "imported": undefined,
                 "name": "z",
                 "start": 56,
               },
               {
                 "end": 60,
-                "imported": undefined,
                 "name": "w",
                 "start": 59,
               },

--- a/src/typescript/transformer.test.ts
+++ b/src/typescript/transformer.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import { tsAnalyze, tsTransformIsort } from "./transformer";
+
+describe("ts-transfomer", () => {
+  it("basic", () => {
+    const input = `\
+import { x, y } from "b";
+import "c";
+import { z, w } from "a";
+`;
+    expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
+      "import { z, w } from \\"a\\";
+      import { x, y } from \\"b\\";
+      import \\"c\\";
+      "
+    `);
+    expect(tsAnalyze(input)).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "end": 25,
+            "fullStart": 0,
+            "source": "b",
+            "specifiers": [
+              {
+                "end": 10,
+                "fullStart": 8,
+                "imported": undefined,
+                "name": "x",
+                "start": 9,
+              },
+              {
+                "end": 13,
+                "fullStart": 11,
+                "imported": undefined,
+                "name": "y",
+                "start": 12,
+              },
+            ],
+            "start": 0,
+          },
+          {
+            "end": 37,
+            "fullStart": 25,
+            "source": "c",
+            "specifiers": undefined,
+            "start": 26,
+          },
+          {
+            "end": 63,
+            "fullStart": 37,
+            "source": "a",
+            "specifiers": [
+              {
+                "end": 48,
+                "fullStart": 46,
+                "imported": undefined,
+                "name": "z",
+                "start": 47,
+              },
+              {
+                "end": 51,
+                "fullStart": 49,
+                "imported": undefined,
+                "name": "w",
+                "start": 50,
+              },
+            ],
+            "start": 38,
+          },
+        ],
+      ]
+    `);
+  });
+
+  it("comment", () => {
+    const input = `\
+// hey
+import { x, y } from "b";
+import "c"; // xxx
+// foo
+import { z, w } from "a";
+`;
+    expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
+      "// hey
+      import { z, w } from \\"a\\";
+      import { x, y } from \\"b\\"; // xxx
+      // foo
+      import \\"c\\";
+      "
+    `);
+    expect(tsAnalyze(input)).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "end": 32,
+            "fullStart": 0,
+            "source": "b",
+            "specifiers": [
+              {
+                "end": 17,
+                "fullStart": 15,
+                "imported": undefined,
+                "name": "x",
+                "start": 16,
+              },
+              {
+                "end": 20,
+                "fullStart": 18,
+                "imported": undefined,
+                "name": "y",
+                "start": 19,
+              },
+            ],
+            "start": 7,
+          },
+          {
+            "end": 44,
+            "fullStart": 32,
+            "source": "c",
+            "specifiers": undefined,
+            "start": 33,
+          },
+          {
+            "end": 84,
+            "fullStart": 44,
+            "source": "a",
+            "specifiers": [
+              {
+                "end": 69,
+                "fullStart": 67,
+                "imported": undefined,
+                "name": "z",
+                "start": 68,
+              },
+              {
+                "end": 72,
+                "fullStart": 70,
+                "imported": undefined,
+                "name": "w",
+                "start": 71,
+              },
+            ],
+            "start": 59,
+          },
+        ],
+      ]
+    `);
+  });
+
+  it("ignore", () => {
+    const input = `\
+import { x, y } from "b";
+// isort-ignore
+import "c";
+import { z, w } from "a";
+`;
+    expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
+      "import { x, y } from \\"b\\";
+      // isort-ignore
+      import \\"c\\";
+      import { z, w } from \\"a\\";
+      "
+    `);
+    expect(tsAnalyze(input)).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "end": 25,
+            "fullStart": 0,
+            "source": "b",
+            "specifiers": [
+              {
+                "end": 10,
+                "fullStart": 8,
+                "imported": undefined,
+                "name": "x",
+                "start": 9,
+              },
+              {
+                "end": 13,
+                "fullStart": 11,
+                "imported": undefined,
+                "name": "y",
+                "start": 12,
+              },
+            ],
+            "start": 0,
+          },
+        ],
+        [
+          {
+            "end": 79,
+            "fullStart": 53,
+            "source": "a",
+            "specifiers": [
+              {
+                "end": 64,
+                "fullStart": 62,
+                "imported": undefined,
+                "name": "z",
+                "start": 63,
+              },
+              {
+                "end": 67,
+                "fullStart": 65,
+                "imported": undefined,
+                "name": "w",
+                "start": 66,
+              },
+            ],
+            "start": 54,
+          },
+        ],
+      ]
+    `);
+  });
+
+  it("multiple groups", () => {
+    const input = `\
+import { x, y } from "b";
+"hello";
+import "c";
+import { z, w } from "a";
+`;
+    expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
+      "import { x, y } from \\"b\\";
+      \\"hello\\";
+      import { z, w } from \\"a\\";
+      import \\"c\\";
+      "
+    `);
+    expect(tsAnalyze(input)).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "end": 25,
+            "fullStart": 0,
+            "source": "b",
+            "specifiers": [
+              {
+                "end": 10,
+                "fullStart": 8,
+                "imported": undefined,
+                "name": "x",
+                "start": 9,
+              },
+              {
+                "end": 13,
+                "fullStart": 11,
+                "imported": undefined,
+                "name": "y",
+                "start": 12,
+              },
+            ],
+            "start": 0,
+          },
+        ],
+        [
+          {
+            "end": 46,
+            "fullStart": 34,
+            "source": "c",
+            "specifiers": undefined,
+            "start": 35,
+          },
+          {
+            "end": 72,
+            "fullStart": 46,
+            "source": "a",
+            "specifiers": [
+              {
+                "end": 57,
+                "fullStart": 55,
+                "imported": undefined,
+                "name": "z",
+                "start": 56,
+              },
+              {
+                "end": 60,
+                "fullStart": 58,
+                "imported": undefined,
+                "name": "w",
+                "start": 59,
+              },
+            ],
+            "start": 47,
+          },
+        ],
+      ]
+    `);
+  });
+
+  it("tsx", () => {
+    const input = `\
+import "b";
+import "a";
+
+<input />
+`;
+    expect(tsTransformIsort(input)).toMatchInlineSnapshot(`
+      "import \\"a\\";
+      import \\"b\\";
+
+      <input />
+      "
+    `);
+    expect(tsAnalyze(input)).toMatchInlineSnapshot(`
+      [
+        [
+          {
+            "end": 11,
+            "fullStart": 0,
+            "source": "b",
+            "specifiers": undefined,
+            "start": 0,
+          },
+          {
+            "end": 23,
+            "fullStart": 11,
+            "source": "a",
+            "specifiers": undefined,
+            "start": 12,
+          },
+        ],
+      ]
+    `);
+  });
+});

--- a/src/typescript/transformer.ts
+++ b/src/typescript/transformer.ts
@@ -1,0 +1,159 @@
+import { tinyassert } from "@hiogawa/utils";
+import { sortBy, zip } from "lodash";
+import ts from "typescript";
+import { DEFAULT_OPTIONS, groupNeighborBy } from "../transform-isort";
+
+// TODO: sortImportSpecifiers
+
+const IGNORE_COMMENTS = ["isort-ignore"];
+
+// minimum parse data to allow sorting afterward
+interface ImportDeclarationInfo {
+  fullStart: number;
+  start: number;
+  end: number;
+  source: string;
+  specifiers?: ImportSpecifierInfo[];
+}
+
+interface ImportSpecifierInfo {
+  fullStart: number;
+  start: number;
+  end: number;
+  name: string;
+  imported?: string;
+}
+
+// cf. https://gist.github.com/hi-ogawa/cb338b4765d25321b120b2a47819abcc
+class TransformerWrapper {
+  result: ImportDeclarationInfo[][] = [];
+
+  getTransformer =
+    (): ts.TransformerFactory<ts.SourceFile> =>
+    (_ctx: ts.TransformationContext) =>
+    (sourceFile: ts.SourceFile) => {
+      // we don't have to visit all AST recursively
+      this.result = extraceImportDeclaration(sourceFile);
+      return sourceFile;
+    };
+}
+
+function extraceImportDeclaration(
+  node: ts.SourceFile
+): ImportDeclarationInfo[][] {
+  const groups: [boolean, ts.Statement[]][] = groupNeighborBy(
+    [...node.statements],
+    (stmt) =>
+      ts.isImportDeclaration(stmt) &&
+      !IGNORE_COMMENTS.some((comment) => getTrivia(stmt).includes(comment))
+  );
+  const result: ImportDeclarationInfo[][] = [];
+  for (const [ok, statements] of groups) {
+    if (!ok) {
+      continue;
+    }
+    const resultGroup = statements.map((node) => {
+      tinyassert(ts.isImportDeclaration(node));
+      tinyassert(ts.isStringLiteral(node.moduleSpecifier));
+      const info: ImportDeclarationInfo = {
+        fullStart: node.getFullStart(),
+        start: node.getStart(),
+        end: node.end,
+        source: node.moduleSpecifier.text,
+        specifiers: extraceImportSpecifier(node),
+      };
+      return info;
+    });
+    result.push(resultGroup);
+  }
+  return result;
+}
+
+function extraceImportSpecifier(
+  node: ts.ImportDeclaration
+): ImportSpecifierInfo[] | undefined {
+  const namedImports = node.importClause?.namedBindings;
+  if (namedImports && ts.isNamedImports(namedImports)) {
+    return namedImports.elements.map((node) => ({
+      fullStart: node.getFullStart(),
+      start: node.getStart(),
+      end: node.end,
+      name: node.name.text,
+      imported: node.propertyName?.text,
+    }));
+  }
+  return;
+}
+
+function getTrivia(node: ts.Node): string {
+  return node.getFullText().slice(0, node.getLeadingTriviaWidth());
+}
+
+//
+// ts transformer driver
+//
+
+export function tsAnalyze(code: string) {
+  const wrapper = new TransformerWrapper();
+  ts.transpileModule(code, {
+    compilerOptions: {},
+    // TODO: tsx mode?
+    fileName: "__dummy.tsx",
+    reportDiagnostics: false,
+    transformers: {
+      before: [wrapper.getTransformer()],
+    },
+  });
+  return wrapper.result;
+}
+
+//
+// codemod
+//
+
+export function tsTransformIsort(code: string): string {
+  const groups = tsAnalyze(code);
+  for (const group of groups) {
+    code = sortImportDeclarations(code, group);
+  }
+  return code;
+}
+
+function sortImportDeclarations(
+  code: string,
+  decls: ImportDeclarationInfo[]
+): string {
+  const start = decls[0]?.fullStart;
+  const end = decls.at(-1)?.end;
+  tinyassert(typeof start === "number");
+  tinyassert(typeof end === "number");
+
+  const sorted = sortBy(
+    decls,
+    (decl) =>
+      DEFAULT_OPTIONS.isortOrder.findIndex((re) => decl.source.match(re)),
+    (decl) =>
+      DEFAULT_OPTIONS.isortCaseInsensitive
+        ? decl.source.toLowerCase()
+        : decl.source
+  );
+
+  // keep existing trivia fixed (this is probably the easiest way to handle new lines naturally)
+  // e.g.
+  //  (trivia y)     (trivia y)
+  //  (import y)  ⇒  (import x)
+  //  (trivia x)     (trivia x)
+  //  (import x)     (import y)
+
+  const triviaRanges = decls.map((decl) => [decl.fullStart, decl.start]);
+  const importRanges = sorted.map((decl) => [decl.start, decl.end]);
+  const allRanges = zip(triviaRanges, importRanges).flat(1) as [
+    number,
+    number
+  ][];
+
+  const result = [[0, start], ...allRanges, [end, code.length]]
+    .map((range) => code.slice(...range))
+    .join("");
+  return result;
+}

--- a/src/typescript/transformer.ts
+++ b/src/typescript/transformer.ts
@@ -71,7 +71,7 @@ function extraceImportSpecifier(
     return namedImports.elements.map((node) => ({
       start: node.getStart(),
       end: node.end,
-      name: node.name.text,
+      name: node.propertyName?.text ?? node.name.text,
     }));
   }
   return;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts", "src/typescript/prettier-plugin.ts"],
+  entry: [
+    "src/index.ts",
+    "src/cli.ts",
+    "src/typescript/prettier-plugin.ts",
+    "src/typescript/cli.ts",
+  ],
   format: ["cjs"],
   splitting: false,
   sourcemap: "inline",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts"],
+  entry: ["src/index.ts", "src/cli.ts", "src/typescript/prettier-plugin.ts"],
   format: ["cjs"],
   splitting: false,
   sourcemap: "inline",


### PR DESCRIPTION
- [x] `sortImportSpecifiers`
- [x] cli
  - [x] standalone?
  - [x] as prettier plugin override?
- [x] move to new repo again https://github.com/hi-ogawa/isort-ts
- [ ] default order for node builtin? (for eslint import/order default compatibility)